### PR TITLE
feat(eslint): Extend typescript-eslint/naming-convention for class public properties

### DIFF
--- a/packages/eslint-config/plugins/typescript-eslint.js
+++ b/packages/eslint-config/plugins/typescript-eslint.js
@@ -55,6 +55,11 @@ module.exports = {
                 format: ['camelCase'],
                 leadingUnderscore: 'allow'
             },
+            {
+                selector: 'classProperty',
+                modifiers: ['public'],
+                format: ['camelCase', 'PascalCase']
+            },
 
             { selector: 'class', format: ['StrictPascalCase'] },
             {


### PR DESCRIPTION
@cooleso 
Изменение нужно для тех случаев, когда нужно в html использовать функционал из ts с тем же именем. Например, энумы или функции. Ниже на скриншоте показал пример с энумом:

![image](https://user-images.githubusercontent.com/4592808/152932429-ff27e353-6969-424c-8017-d0a923bd05c6.png)


Такой кейс особенно оправдан в тех случаях, когда при использовании имени в camelCase есть пересечение с уже имеющимся полем, например с инпутом.