### PR TITLE
feat: change type naming style

### DIFF
--- a/packages/eslint-config/plugins/typescript-eslint.js
+++ b/packages/eslint-config/plugins/typescript-eslint.js
@@ -71,7 +71,7 @@ module.exports = {
             { selector: 'accessor', format: ['camelCase'] },
             { selector: 'enum', format: ['StrictPascalCase'] },
             { selector: 'enumMember', format: ['PascalCase', 'UPPER_CASE'] },
-            { selector: 'typeLike', format: ['StrictPascalCase'] },
+            { selector: 'typeLike', format: ['PascalCase'] },
             { selector: 'interface', format: ['PascalCase'] }
         ],
 


### PR DESCRIPTION
Предлагаю для типов изменить naming-convention на PascalCase вместо StrictPascalCase, т.к. у нас внутри проекта к типам по аналогии с интерфейсами добавляется заглавная T. Ну и в принципе непонятно различие в именовании между типами и интерфейсами